### PR TITLE
Dotted underlines issue

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -9,6 +9,7 @@ body {
 a {
   color: rgba(0, 0, 0, 0.8);
   text-decoration: dotted underline;
+  text-decoration-skip-ink: none; /* https://stackoverflow.com/questions/50007283/dotted-underlines-dont-render-properly-in-chrome */
 }
 
 section > div {


### PR DESCRIPTION
…ections of the dotted underline were missing

TODO: Fix issue where double dotted lines rendering at beginning and end:
* https://stackoverflow.com/questions/45335437/dotted-lines-in-chrome
* https://stackoverflow.com/questions/46318491/border-bottom-dotted-has-solid-line-at-start-end-in-chrome
* Tried the border-bottom in after pseudoclass solution but this doesn't work well because
  * it requires display: inline-block on the element to underline, which will cause a long link text to start on its own line
  * for links that span multiple lines, the underline will only be applied to the last line